### PR TITLE
Pin versions of other extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A JupyterLab extension.
 ## Installation
 
 ```bash
-jupyter labextension install metadata_explorer_service @jupyterlab/dataregistry-extension @jupyterlab/metadata-extension
+jupyter labextension install metadata_explorer_service @jupyterlab/dataregistry-extension@3.0.0 @jupyterlab/metadata-extension@1.5.0
 ```
 
 ## Development


### PR DESCRIPTION
We have since released new versions of the metadata extension. Until this extension is upgraded to be compatible with that, you should install the older version of those extensions.